### PR TITLE
fix: rename param in EF script step, add restore for test proj in net…

### DIFF
--- a/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
+++ b/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
@@ -16,19 +16,16 @@ parameters:
     default: 'EFMigrationScript'
 
 steps:
-  - task: DotNetCoreCLI@2
-    displayName: .NET Restore
-    inputs:
-      command: restore
-      projects: ${{parameters.defaultProject}}
-      vstsFeed: 'Audacia.Public/AudaciaPublic'
-  
-  - task: DotNetCoreCLI@2
-    displayName: .NET Restore
-    inputs:
-      command: restore
-      projects: ${{parameters.startupProject}}
-      vstsFeed: 'Audacia.Public/AudaciaPublic'
+  # if default project is provided, startup should also be provided
+  - ${{ if not(eq(length(parameters.defaultProject), 0)) }}:
+    - task: DotNetCoreCLI@2
+      displayName: .NET Restore
+      inputs:
+        command: restore
+        projects: |
+            ${{parameters.defaultProject}}
+            ${{parameters.startupProject}}
+        vstsFeed: 'Audacia.Public/AudaciaPublic'
 
   - task: PowerShell@2
     displayName: ${{parameters.displayName}}

--- a/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
+++ b/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
@@ -4,9 +4,9 @@ parameters:
     default: 'Build EF Core Migration Scripts'
   - name: dbContext # (required) The name of the database context for the application.
     default: 'DatabaseContext'
-  - name: defaultProject # (optional) The entity framework project which contains the database context.
+  - name: defaultProject # (optional) The path to the csproj of the entity framework project which contains the database context.
     default: ''
-  - name: startupProject # (optional) The executable project that contains the appsettings.json file.
+  - name: startupProject # (optional) The path to the csproj of the executable project that contains the appsettings.json file.
     default: ''
   - name: dotNetToolsManifest # The location of the dotnet tools manifest. Defaults to the root of the source repository.
     default: '$(Build.SourcesDirectory)/.config/dotnet-tools.json'
@@ -20,7 +20,14 @@ steps:
     displayName: .NET Restore
     inputs:
       command: restore
-      projects: ${{parameters.efProjectPath}}
+      projects: ${{parameters.defaultProject}}
+      vstsFeed: 'Audacia.Public/AudaciaPublic'
+  
+  - task: DotNetCoreCLI@2
+    displayName: .NET Restore
+    inputs:
+      command: restore
+      projects: ${{parameters.startupProject}}
       vstsFeed: 'Audacia.Public/AudaciaPublic'
 
   - task: PowerShell@2

--- a/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
+++ b/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml
@@ -16,17 +16,6 @@ parameters:
     default: 'EFMigrationScript'
 
 steps:
-  # if default project is provided, startup should also be provided
-  - ${{ if not(eq(length(parameters.defaultProject), 0)) }}:
-    - task: DotNetCoreCLI@2
-      displayName: .NET Restore
-      inputs:
-        command: restore
-        projects: |
-            ${{parameters.defaultProject}}
-            ${{parameters.startupProject}}
-        vstsFeed: 'Audacia.Public/AudaciaPublic'
-
   - task: PowerShell@2
     displayName: ${{parameters.displayName}}
     inputs:

--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -34,14 +34,12 @@ steps:
     displayName: .NET Restore
     inputs:
       command: restore
-      projects: ${{parameters.projects}}
-      vstsFeed: 'Audacia.Public/AudaciaPublic'
-      
-  - task: DotNetCoreCLI@2
-    displayName: .NET Restore
-    inputs:
-      command: restore
-      projects: ${{parameters.tests}}
+      ${{ if eq(parameters.runTests, true) }}:
+        projects: |
+            ${{parameters.projects}}
+            ${{parameters.tests}}
+      ${{ else }}:
+        projects: ${{parameters.projects}}
       vstsFeed: 'Audacia.Public/AudaciaPublic'
 
   - task: DotNetCoreCLI@2

--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -36,6 +36,13 @@ steps:
       command: restore
       projects: ${{parameters.projects}}
       vstsFeed: 'Audacia.Public/AudaciaPublic'
+      
+  - task: DotNetCoreCLI@2
+    displayName: .NET Restore
+    inputs:
+      command: restore
+      projects: ${{parameters.tests}}
+      vstsFeed: 'Audacia.Public/AudaciaPublic'
 
   - task: DotNetCoreCLI@2
     displayName: .NET Build


### PR DESCRIPTION
Removal of restore step in EF idempotent template - both as unnecessary and to remove the incorrect parameter name
Addition of test project into the restore step on the net-core template if testing, as this needs to build with the reference to the Audacia libraries

| Action | Done? |
| --- | --- |
| CHANGELOG updated | ❌ |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ❌ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ❌ |
