### PR TITLE
Update default artifactname for EF Migration Script task

### DIFF
--- a/src/deployment/efcore/tasks/migrate-idempotent-script.yaml
+++ b/src/deployment/efcore/tasks/migrate-idempotent-script.yaml
@@ -5,7 +5,7 @@ parameters:
   - name: displayName
     default: 'Migrate Azure SQL Database'
   - name: artifactName
-    default: 'Migrations'
+    default: 'EFMigrationScript'
   - name: dbContext # Name of the DbContext
     default: ''
   - name: azureSubscription # Azure Subscription for the resource


### PR DESCRIPTION
Sets the artifactName parameter default  in the deploy to the same as the default artifactName in the build of the EF Migration Script - https://github.com/audaciaconsulting/Audacia.Build/blob/f9f690ade268febb75886eab7d901aa86fea03ec/src/build/dotnet/steps/ef-migration-idempotent-script.steps.yaml#L15-L16