### PR TITLE
fix: Renewal pipeline now uses azcli login type to rely on tenantId #190826

### DIFF
--- a/src/deployment/certificates/tasks/renew-certificates.yaml
+++ b/src/deployment/certificates/tasks/renew-certificates.yaml
@@ -44,8 +44,7 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-          $env:AZCOPY_SPA_CLIENT_SECRET=$env:servicePrincipalKey
-          azcopy login --service-principal --application-id $env:servicePrincipalId --tenant-id $env:tenantId
+          azcopy login --login-type azcli --tenant-id $env:tenantId
       addSpnToEnvironment: true
       powerShellErrorActionPreference: 'stop'
       failOnStandardError: true


### PR DESCRIPTION
### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ❎ Changes do not require documentation

### Added/updated logging
- ❎ No significant code changes

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ✔ All secrets and variables are securely managed and documented

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ❎ No changes to pipeline steps

### Security vulnerabilities checked
- ✔ No new security vulnerabilities introduced/external dependencies are secure and up-to-date
