### PR TITLE
Feature/pass in nuget config

### DIFF
--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -11,7 +11,11 @@ parameters:
   - name: artifactName                 # OPTIONAL: The name of the DevOps artifact to publish the built projects to
     default: '$(Build.DefinitionName)'
   - name: nugetConfigPath              # OPTIONAL: Path to the NuGet.Config file
-    default: '$(Build.SourcesDirectory)/src/apis'
+    default: '$(Build.SourcesDirectory)/src/apis/nuget.config'
+  - name: feedsToUse                   # OPTIONAL: Should vstsFeed be used or nugetConfigPath
+    default: 'select'
+  - name: feed                         # OPTIONAL: Vsts feed to be used
+    default: 'Audacia.Public/AudaciaPublic'
 
 steps:
   - task: DotNetCoreCLI@2
@@ -24,8 +28,10 @@ steps:
           ${{parameters.tests}}
       ${{ else }}:
         projects: ${{parameters.projects}}
-      feedsToUse: 'config'
-      nugetConfigPath: ${{parameters.nugetConfigPath}}/nuget.config
+      ${{ if eq(parameters.feedsToUse, 'select') }}:
+        vstsFeed: ${{parameters.feed}}
+      ${{ else }}:
+        nugetConfigPath: ${{parameters.nugetConfigPath}}
 
   - task: DotNetCoreCLI@2
     displayName: .NET Build

--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -10,12 +10,15 @@ parameters:
     default: 'Release'
   - name: artifactName                 # OPTIONAL: The name of the DevOps artifact to publish the built projects to
     default: '$(Build.DefinitionName)'
+  - name: feedsToUse                   # OPTIONAL: Should vstsFeed be used or nugetConfigPath
+    default: 'vstsFeed'
+    values:
+      - 'vstsFeed'
+      - 'nugetConfigPath'
+  - name: vstsFeed                     # OPTIONAL: VSTS feed to be used
+    default: 'Audacia.Public/AudaciaPublic'
   - name: nugetConfigPath              # OPTIONAL: Path to the NuGet.Config file
     default: '$(Build.SourcesDirectory)/src/apis/nuget.config'
-  - name: feedsToUse                   # OPTIONAL: Should vstsFeed be used or nugetConfigPath
-    default: 'select'
-  - name: feed                         # OPTIONAL: Vsts feed to be used
-    default: 'Audacia.Public/AudaciaPublic'
 
 steps:
   - task: DotNetCoreCLI@2
@@ -28,8 +31,8 @@ steps:
           ${{parameters.tests}}
       ${{ else }}:
         projects: ${{parameters.projects}}
-      ${{ if eq(parameters.feedsToUse, 'select') }}:
-        vstsFeed: ${{parameters.feed}}
+      ${{ if eq(parameters.feedsToUse, 'vstsFeed') }}:
+        vstsFeed: ${{parameters.vstsFeed}}
       ${{ else }}:
         nugetConfigPath: ${{parameters.nugetConfigPath}}
 

--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -11,7 +11,7 @@ parameters:
   - name: artifactName                 # OPTIONAL: The name of the DevOps artifact to publish the built projects to
     default: '$(Build.DefinitionName)'
   - name: nugetConfigPath              # OPTIONAL: Path to the NuGet.Config file
-    default: '$(Build.SourcesDirectory)'
+    default: '$(Build.SourcesDirectory)/src/apis'
 
 steps:
   - task: DotNetCoreCLI@2

--- a/src/build/dotnet/steps/net-core.steps.yaml
+++ b/src/build/dotnet/steps/net-core.steps.yaml
@@ -10,6 +10,8 @@ parameters:
     default: 'Release'
   - name: artifactName                 # OPTIONAL: The name of the DevOps artifact to publish the built projects to
     default: '$(Build.DefinitionName)'
+  - name: nugetConfigPath              # OPTIONAL: Path to the NuGet.Config file
+    default: '$(Build.SourcesDirectory)'
 
 steps:
   - task: DotNetCoreCLI@2
@@ -22,7 +24,8 @@ steps:
           ${{parameters.tests}}
       ${{ else }}:
         projects: ${{parameters.projects}}
-      vstsFeed: 'Audacia.Public/AudaciaPublic'
+      feedsToUse: 'config'
+      nugetConfigPath: ${{parameters.nugetConfigPath}}/nuget.config
 
   - task: DotNetCoreCLI@2
     displayName: .NET Build


### PR DESCRIPTION
### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ❎ Changes do not require documentation

### Added/updated logging
- ❎ No significant code changes

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ❎ No changes to secrets or variables

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ❎ No changes to pipeline steps

### Security vulnerabilities checked
- ❎ No new dependencies or changes affecting security


Added the ability to choose whether to use the default Audacia.Public vsts feed, or opt in to point towards a nuget.config file.
The need for this is when working in a different devops organisation, .net restore currently looks for Audacia.Public in the clients organisation, rather than audacia's.

Can opt in by specifying to use the nugetPathConfig when calling the step.

```
- template: /src/build/dotnet/steps/net-core.steps.yaml@templates
            parameters:
              projects: "**/*.Api.csproj"
              tests: "**/*.Tests.csproj"
              artifactName: "Api"
              feedsToUse: 'nugetConfigPath'
```

![image](https://github.com/user-attachments/assets/82d6e943-e881-4ce9-b1a5-57466c8c61f9)

