### PR TITLE
feat: Filter out empty or whitespace-only service names #197394

### DIFF
--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -21,6 +21,11 @@ steps:
         # Filter out empty or whitespace-only service names
         $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 
+        # Ensure at least one app service is specified
+        if ($ResourceNames.Count -eq 0) {
+            throw "No app services specified. At least one app service name must be provided."
+        }
+
         $ResourceGroupName = '${{parameters.resourceGroupName}}'
         $slotName = '${{parameters.slotName}}'
         $slotSwapCompleted = [System.Collections.Concurrent.ConcurrentBag[string]]::new()

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -8,6 +8,9 @@ parameters:
   - name: appServices # The names of the app services to swap the slots in
     default: []
     type: object
+  - name: ignoreEmptyAppServices # Option to ignore empty entries in the appServices list
+    type: boolean
+    default: false
 
 steps:
   - task: AzureCLI@2
@@ -18,8 +21,11 @@ steps:
       scriptLocation: inlineScript
       inlineScript: |
         $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
-        # Filter out empty or whitespace-only service names
+        # only drop empty entries when requested
+        $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
+        if ($ignoreEmpty) {
         $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        }
 
         $ResourceGroupName = '${{parameters.resourceGroupName}}'
         $slotName = '${{parameters.slotName}}'

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -21,15 +21,16 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        # read the boolean flag that was expanded at compile-time
+        # read the boolean flag (expanded at compile-time)
         $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
 
-        # parse the array of app-service names
-        $ResourceNames = '${{ convertToJson(parameters.appServices) }}' | ConvertFrom-Json
+        # parse the array of app-service names (ensure variable macros are expanded first)
+        $ResourceNames = "${{ convertToJson(parameters.appServices) }}" | ConvertFrom-Json
 
-        # drop empty or whitespace-only entries when requested
+        # if requested, drop any empty or whitespace-only entries
         if ($ignoreEmpty) {
-            $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            $ResourceNames = $ResourceNames |
+              Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
         }
 
         $ResourceGroupName = '${{ parameters.resourceGroupName }}'
@@ -41,20 +42,20 @@ steps:
             $target = $_
             try {
                 Write-Host "Starting swap for $target"
-                az webapp deployment slot swap -g $using:ResourceGroupName -n $target --slot $using:slotName --target-slot production | ConvertFrom-Json
-        
-                if (!$?) 
-                {
-                    throw "Swap failed for $target"            
-                } 
-                else 
-                {
+                az webapp deployment slot swap `
+                  -g $using:ResourceGroupName `
+                  -n $target `
+                  --slot $using:slotName `
+                  --target-slot production | ConvertFrom-Json
+
+                if (!$?) {
+                    throw "Swap failed for $target"
+                } else {
                     ($using:slotSwapCompleted).Add($target)
                     Write-Host "Completed swap for $target successfully"
                 }
-            } 
-            catch 
-            {
+            }
+            catch {
                 Write-Host "Exception during swap for $($target): $_"
                 ($using:slotSwapErrored).Add($target)
             }
@@ -63,16 +64,17 @@ steps:
         Write-Host "Slots swapped successfully: $($slotSwapCompleted.Count)"
         Write-Host "Slot swap errors: $($slotSwapErrored.Count)"
 
-        if($slotSwapErrored.Count -gt 0)
-        {
+        if ($slotSwapErrored.Count -gt 0) {
             $slotSwapCompleted | ForEach-Object {
                 $target = $_
                 Write-Host "Reversing slot swap for $target"
-                az webapp deployment slot swap -g $ResourceGroupName -n $target --slot $slotName --target-slot production | ConvertFrom-Json
+                az webapp deployment slot swap `
+                  -g $ResourceGroupName `
+                  -n $target `
+                  --slot $slotName `
+                  --target-slot production | ConvertFrom-Json
             }
             exit 1
-        } 
-        else 
-        {
+        } else {
             exit 0
         }

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -21,10 +21,9 @@ steps:
       scriptLocation: inlineScript
       inlineScript: |
         $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
-        # only drop empty entries when requested
-          $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
-          if ($ignoreEmpty) {
-          $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        ${{ if eq(parameters.ignoreEmptyAppServices, true) }}:
+          # drop any empty or whitespace-only names
+          $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) 
         }
 
         $ResourceGroupName = '${{parameters.resourceGroupName}}'

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -1,14 +1,15 @@
 parameters:
-  - name: serviceConnectionName # The name of the service connection used to deploy to Azure
+  - name: serviceConnectionName    # The name of the service connection used to deploy to Azure
     type: string
-  - name: slotName # The name of the slot to deploy to, that will be swapped into production
+  - name: slotName                 # The name of the slot to deploy to, that will be swapped into production
+    type: string
     default: 'Staging'
-  - name: resourceGroupName # The name of the resource group the app services are in
+  - name: resourceGroupName        # The name of the resource group the app services are in
     type: string
-  - name: appServices # The names of the app services to swap the slots in
-    default: []
+  - name: appServices              # The names of the app services to swap the slots in
     type: object
-  - name: ignoreEmptyAppServices # Option to ignore empty entries in the appServices list
+    default: []
+  - name: ignoreEmptyAppServices   # Whether to drop empty or whitespace-only names before swapping
     type: boolean
     default: false
 
@@ -16,20 +17,25 @@ steps:
   - task: AzureCLI@2
     displayName: 'Swap Slots'
     inputs:
-      azureSubscription: ${{parameters.serviceConnectionName}}
+      azureSubscription: ${{ parameters.serviceConnectionName }}
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
-        ${{ if eq(parameters.ignoreEmptyAppServices, true) }}:
-          # drop any empty or whitespace-only names
-          $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) 
+        # read the boolean flag that was expanded at compile-time
+        $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
+
+        # parse the array of app-service names
+        $ResourceNames = '${{ convertToJson(parameters.appServices) }}' | ConvertFrom-Json
+
+        # drop empty or whitespace-only entries when requested
+        if ($ignoreEmpty) {
+            $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
         }
 
-        $ResourceGroupName = '${{parameters.resourceGroupName}}'
-        $slotName = '${{parameters.slotName}}'
+        $ResourceGroupName = '${{ parameters.resourceGroupName }}'
+        $slotName          = '${{ parameters.slotName }}'
         $slotSwapCompleted = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
-        $slotSwapErrored = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
+        $slotSwapErrored   = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
 
         $ResourceNames | ForEach-Object -Parallel {
             $target = $_

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -22,9 +22,9 @@ steps:
       inlineScript: |
         $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
         # only drop empty entries when requested
-        $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
-        if ($ignoreEmpty) {
-        $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+          $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
+          if ($ignoreEmpty) {
+          $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
         }
 
         $ResourceGroupName = '${{parameters.resourceGroupName}}'

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -1,61 +1,46 @@
 parameters:
-  - name: serviceConnectionName    # The name of the service connection used to deploy to Azure
+  - name: serviceConnectionName # The name of the service connection used to deploy to Azure
     type: string
-  - name: slotName                 # The name of the slot to deploy to, that will be swapped into production
-    type: string
+  - name: slotName # The name of the slot to deploy to, that will be swapped into production
     default: 'Staging'
-  - name: resourceGroupName        # The name of the resource group the app services are in
+  - name: resourceGroupName # The name of the resource group the app services are in
     type: string
-  - name: appServices              # The names of the app services to swap the slots in
-    type: object
+  - name: appServices # The names of the app services to swap the slots in
     default: []
-  - name: ignoreEmptyAppServices   # Whether to drop empty or whitespace-only names before swapping
-    type: boolean
-    default: false
+    type: object
 
 steps:
   - task: AzureCLI@2
     displayName: 'Swap Slots'
     inputs:
-      azureSubscription: ${{ parameters.serviceConnectionName }}
+      azureSubscription: ${{parameters.serviceConnectionName}}
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        # read the boolean flag (expanded at compile-time)
-        $ignoreEmpty = ${{ parameters.ignoreEmptyAppServices }}
-
-        # parse the array of app-service names (ensure variable macros are expanded first)
-        $ResourceNames = "${{ convertToJson(parameters.appServices) }}" | ConvertFrom-Json
-
-        # if requested, drop any empty or whitespace-only entries
-        if ($ignoreEmpty) {
-            $ResourceNames = $ResourceNames |
-              Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-        }
-
-        $ResourceGroupName = '${{ parameters.resourceGroupName }}'
-        $slotName          = '${{ parameters.slotName }}'
+        $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
+        $ResourceGroupName = '${{parameters.resourceGroupName}}'
+        $slotName = '${{parameters.slotName}}'
         $slotSwapCompleted = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
-        $slotSwapErrored   = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
+        $slotSwapErrored = [System.Collections.Concurrent.ConcurrentBag[string]]::new()
 
         $ResourceNames | ForEach-Object -Parallel {
             $target = $_
             try {
                 Write-Host "Starting swap for $target"
-                az webapp deployment slot swap `
-                  -g $using:ResourceGroupName `
-                  -n $target `
-                  --slot $using:slotName `
-                  --target-slot production | ConvertFrom-Json
-
-                if (!$?) {
-                    throw "Swap failed for $target"
-                } else {
+                az webapp deployment slot swap -g $using:ResourceGroupName -n $target --slot $using:slotName --target-slot production | ConvertFrom-Json
+        
+                if (!$?) 
+                {
+                    throw "Swap failed for $target"            
+                } 
+                else 
+                {
                     ($using:slotSwapCompleted).Add($target)
                     Write-Host "Completed swap for $target successfully"
                 }
-            }
-            catch {
+            } 
+            catch 
+            {
                 Write-Host "Exception during swap for $($target): $_"
                 ($using:slotSwapErrored).Add($target)
             }
@@ -64,17 +49,16 @@ steps:
         Write-Host "Slots swapped successfully: $($slotSwapCompleted.Count)"
         Write-Host "Slot swap errors: $($slotSwapErrored.Count)"
 
-        if ($slotSwapErrored.Count -gt 0) {
+        if($slotSwapErrored.Count -gt 0)
+        {
             $slotSwapCompleted | ForEach-Object {
                 $target = $_
                 Write-Host "Reversing slot swap for $target"
-                az webapp deployment slot swap `
-                  -g $ResourceGroupName `
-                  -n $target `
-                  --slot $slotName `
-                  --target-slot production | ConvertFrom-Json
+                az webapp deployment slot swap -g $ResourceGroupName -n $target --slot $slotName --target-slot production | ConvertFrom-Json
             }
             exit 1
-        } else {
+        } 
+        else 
+        {
             exit 0
         }

--- a/src/deployment/azure/tasks/swap-slots.yaml
+++ b/src/deployment/azure/tasks/swap-slots.yaml
@@ -18,6 +18,9 @@ steps:
       scriptLocation: inlineScript
       inlineScript: |
         $ResourceNames = '${{convertToJson(parameters.appServices)}}' | ConvertFrom-Json;
+        # Filter out empty or whitespace-only service names
+        $ResourceNames = $ResourceNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
         $ResourceGroupName = '${{parameters.resourceGroupName}}'
         $slotName = '${{parameters.slotName}}'
         $slotSwapCompleted = [System.Collections.Concurrent.ConcurrentBag[string]]::new()


### PR DESCRIPTION
# Summary
- This PR  removes any empty or whitespace-only service names in `appServices` automatically before slot swapping.
- If, after processing, there are no `appServices` actually passed in to swap then throw an error.

**Why This Improves the Template**

- **Non-breaking, additive change**: existing pipelines behave exactly as before.
- **Conditional deployments**: supports scenarios where certain App Service slots are only provisioned in specific environments, preventing errors caused by blank entries.
- **Simplified configuration**: removes the need for external preprocessing or complex variable logic to omit empty service names.
---
Error message if there are no app services passed in:
![image](https://github.com/user-attachments/assets/58f7e175-c611-4bdb-a42d-454b1615ea94)


---
### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ❎ Changes do not require documentation

### Added/updated logging
- ❎ No significant code changes

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ❎ No changes to secrets or variables

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ❎ No changes to pipeline steps

### Security vulnerabilities checked
- ❎ No new dependencies or changes affecting security

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR