### PR TITLE
Bug/44 default suppression list not in use

### DIFF
--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -50,7 +50,7 @@ steps:
       ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '') }}:
+      ${{ if eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,11 +47,11 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,10 +47,10 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if ne(variables['suppressionsPath'], '') }}:
+      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -21,16 +21,6 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-    displayName: 'Download base suppression file'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
-        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
-        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
-        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
-
-  - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
@@ -61,7 +51,7 @@ steps:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if eq(variables['suppressionsPath'], '') }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression $(baseSuppressionFile)"'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,10 +47,10 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -22,7 +22,6 @@ steps:
 
   # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
-    name: setVarsNpm
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -20,6 +20,52 @@ steps:
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
+       # Step 1: Set suppressionsPath (runtime variable)
+  - task: PowerShell@2
+    name: setVars
+    displayName: Find Suppressions File
+    condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
+    inputs:
+    targetType: inline
+    pwsh: true
+    script: |
+      Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
+
+      if (Test-Path "${{parameters.suppressionsFilePath}}") {
+        Write-Host "Suppressions file found"
+        Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
+        Write-Host "##vso[task.setvariable variable=hasSuppression]true"
+      }
+      else {
+        Write-Host "Suppressions file not found"
+        Write-Host "##vso[task.setvariable variable=hasSuppression]false"
+      }
+
+# Step 2a: Dependency check WITH suppressions
+  - task: dependency-check-build-task@6
+    displayName: NPM Dependency Check (with suppressions)
+    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
+    continueOnError: ${{parameters.continueIfVulnerabilities}}
+    inputs:
+    projectName: ${{parameters.projectName}}
+    scanPath: '${{parameters.path}}/package-lock.json'
+    format: 'HTML,JUNIT'
+    failOnCVSS: '1'
+    additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+    suppressionPath: '$(suppressionsPath)'
+
+# Step 2b: Dependency check WITHOUT suppressions
+  - task: dependency-check-build-task@6
+    displayName: NPM Dependency Check (no suppressions)
+    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
+    continueOnError: ${{parameters.continueIfVulnerabilities}}
+    inputs:
+    projectName: ${{parameters.projectName}}
+    scanPath: '${{parameters.path}}/package-lock.json'
+    format: 'HTML,JUNIT'
+    failOnCVSS: '1'
+    additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+
   - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,11 +47,9 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"  --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,7 +47,7 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"  --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,9 +47,11 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"  --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
+      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
+        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -14,7 +14,6 @@ parameters:
     default: '$(Build.SourcesDirectory)/suppressions.xml'
 
 steps:
-  # Ensure Java is available for dependency check
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '11'
@@ -23,7 +22,7 @@ steps:
 
   # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
-    name: setVars
+    name: setVarsNpm
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -50,7 +50,7 @@ steps:
       ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '')) }}:
+      ${{ if eq(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -48,8 +48,7 @@ steps:
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
-        suppressionPath: $(suppressionsPath)
+      suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -8,110 +8,85 @@ parameters:
     default: ''
   - name: runEvenIfError
     default: false
-  - name: continueIfVulnerabilities # Should the pipeline continue if vulnerabilities are found?
+  - name: continueIfVulnerabilities
     default: false
   - name: suppressionsFilePath
     default: '$(Build.SourcesDirectory)/suppressions.xml'
 
 steps:
+  # Ensure Java is available for dependency check
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
-       # Step 1: Set suppressionsPath (runtime variable)
+  # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
     name: setVars
-    displayName: Find Suppressions File
-    condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
-    inputs:
-    targetType: inline
-    pwsh: true
-    script: |
-      Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
-
-      if (Test-Path "${{parameters.suppressionsFilePath}}") {
-        Write-Host "Suppressions file found"
-        Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
-        Write-Host "##vso[task.setvariable variable=hasSuppression]true"
-      }
-      else {
-        Write-Host "Suppressions file not found"
-        Write-Host "##vso[task.setvariable variable=hasSuppression]false"
-      }
-
-# Step 2a: Dependency check WITH suppressions
-  - task: dependency-check-build-task@6
-    displayName: NPM Dependency Check (with suppressions)
-    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
-    continueOnError: ${{parameters.continueIfVulnerabilities}}
-    inputs:
-    projectName: ${{parameters.projectName}}
-    scanPath: '${{parameters.path}}/package-lock.json'
-    format: 'HTML,JUNIT'
-    failOnCVSS: '1'
-    additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-    suppressionPath: '$(suppressionsPath)'
-
-# Step 2b: Dependency check WITHOUT suppressions
-  - task: dependency-check-build-task@6
-    displayName: NPM Dependency Check (no suppressions)
-    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
-    continueOnError: ${{parameters.continueIfVulnerabilities}}
-    inputs:
-    projectName: ${{parameters.projectName}}
-    scanPath: '${{parameters.path}}/package-lock.json'
-    format: 'HTML,JUNIT'
-    failOnCVSS: '1'
-    additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-
-  - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
       targetType: inline
       pwsh: true
       script: |
-          Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
+        Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
 
-          if (Test-Path ${{parameters.suppressionsFilePath}} ){
-            Write-Host "Suppressions file found"
-            echo "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
-          }
-          else {
-            Write-Host "Suppressions file not found, no suppressions will be provided"
-            echo "##vso[task.setvariable variable=suppressionsPath]$null"
-          }
+        if (Test-Path "${{parameters.suppressionsFilePath}}") {
+          Write-Host "Suppressions file found"
+          Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
+          Write-Host "##vso[task.setvariable variable=hasSuppression]true"
+        }
+        else {
+          Write-Host "Suppressions file not found"
+          Write-Host "##vso[task.setvariable variable=hasSuppression]false"
+        }
 
+  # Step 2a: Dependency check WITH suppressions
   - task: dependency-check-build-task@6
-    displayName: NPM Dependency Check
-    condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
+    displayName: NPM Dependency Check (with suppressions)
+    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-    # Check if report exists, when not skipped and artifact name provided
-  - powershell: |
-      if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {
-        echo "##vso[task.setVariable variable=ReportExists]true"
-      }
+      suppressionPath: '$(suppressionsPath)'
+
+  # Step 2b: Dependency check WITHOUT suppressions
+  - task: dependency-check-build-task@6
+    displayName: NPM Dependency Check (no suppressions)
+    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
+    continueOnError: ${{parameters.continueIfVulnerabilities}}
+    inputs:
+      projectName: ${{parameters.projectName}}
+      scanPath: '${{parameters.path}}/package-lock.json'
+      format: 'HTML,JUNIT'
+      failOnCVSS: '1'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+
+  # Check if report exists, when not skipped and artifact name provided
+  - task: PowerShell@2
     displayName: Check for Dependency Check Report
     condition: and(succeededOrFailed(), ne('${{parameters.publishAs}}', ''))
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        if (Test-Path "$(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html") {
+          Write-Host "##vso[task.setVariable variable=ReportExists]true"
+        }
 
-
-    # Republish report to unique artifact
+  # Republish report to unique artifact
   - publish: $(Common.TestResultsDirectory)\dependency-check
-    condition: eq(variables.ReportExists, 'true')
     displayName: Republish Dependency Check Report
+    condition: eq(variables['ReportExists'], 'true')
     artifact: ${{parameters.publishAs}}
 
   - task: PublishTestResults@2
-    displayName: "Publish JUnit Results"
+    displayName: Publish JUnit Results
     condition: succeededOrFailed()
     inputs:
       testResultsFormat: 'JUnit'

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,10 +47,10 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -43,7 +43,7 @@ steps:
   # Step 2a: Dependency check WITH suppressions
   - task: dependency-check-build-task@6
     displayName: NPM Dependency Check (with suppressions)
-    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
+    condition: and(or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed())), eq(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
       projectName: ${{parameters.projectName}}
@@ -56,7 +56,7 @@ steps:
   # Step 2b: Dependency check WITHOUT suppressions
   - task: dependency-check-build-task@6
     displayName: NPM Dependency Check (no suppressions)
-    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
+    condition: and(or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed())), ne(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
       projectName: ${{parameters.projectName}}

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -58,6 +58,7 @@ steps:
     displayName: Check for Dependency Check Report
     condition: and(succeededOrFailed(), ne('${{parameters.publishAs}}', ''))
 
+
     # Republish report to unique artifact
   - publish: $(Common.TestResultsDirectory)\dependency-check
     condition: eq(variables.ReportExists, 'true')

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,7 +47,7 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"  --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -43,7 +43,8 @@ steps:
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      suppressionPath: $(suppressionsPath)
+      ${{ if ne(variables['suppressionsPath'], 'null') && ne(variables['suppressionsPath'], '') }}:
+        suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -21,6 +21,16 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
+    displayName: 'Download base suppression file'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
+        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
+        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
+        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
+
+  - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
@@ -51,7 +61,7 @@ steps:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if eq(variables['suppressionsPath'], '') }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression $(baseSuppressionFile)"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,11 +47,11 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
+      additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
+        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -47,10 +47,10 @@ steps:
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -51,7 +51,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -43,14 +43,13 @@ steps:
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      ${{ if ne(variables['suppressionsPath'], 'null') && ne(variables['suppressionsPath'], '') }}:
-        suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-
+      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+        suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/npm-dependency-check.steps.yaml
@@ -43,12 +43,12 @@ steps:
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
+      suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '${{parameters.path}}/package-lock.json'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nodeAuditSkipDevDependencies --disableNodeJS --nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-      suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,11 +45,12 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
+
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -28,7 +28,7 @@ steps:
         $filePath = "$(Build.SourcesDirectory)"
         Write-Host "Listing contents of folder containing suppression file:"
         $dir = Split-Path -Path $filePath
-        Get-ChildItem -Path $dir -Recurse
+        Get-ChildItem -Path $dir
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,7 +45,7 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -20,6 +20,7 @@ steps:
 
   - task: PowerShell@2
     displayName: 'Debug suppression path'
+    condition: always()
     inputs:
       targetType: 'inline'
       pwsh: true

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -23,9 +23,8 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-       $filePath = "${{ parameters.suppressionsFilePath }}"
        echo "Listing contents of suppression folder:"
-       dir $filePath
+       dir "${{ parameters.suppressionsFilePath }}"
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,15 +19,13 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-    displayName: 'Debug suppression path'
+      displayName: 'Debug suppression path'
     inputs:
       targetType: 'inline'
-      pwsh: true
       script: |
-        $filePath = "${{ parameters.suppressionsFilePath }}"
-        Write-Host "Listing contents of folder containing suppression file:"
-        $dir = Split-Path -Path $filePath
-        Get-ChildItem -Path $dir
+       $filePath = "${{ parameters.suppressionsFilePath }}"
+       echo "Listing contents of suppression folder:"
+       dir $filePath
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,12 +19,14 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-      displayName: 'Debug suppression path'
+    displayName: 'Download base suppression file'
     inputs:
       targetType: 'inline'
       script: |
-       echo "Listing contents of suppression folder:"
-       dir "${{ parameters.suppressionsFilePath }}"
+        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
+        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
+        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
+        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,14 +19,12 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-    displayName: 'Download base suppression file'
+      displayName: 'Debug suppression path'
     inputs:
       targetType: 'inline'
       script: |
-        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
-        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
-        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
-        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
+       echo "Listing contents of suppression folder:"
+       dir "${{ parameters.suppressionsFilePath }}"
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -46,7 +46,7 @@ steps:
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-    suppressionPath: $(suppressionsPath)
+      suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,11 +45,9 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,7 +45,7 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -46,8 +46,7 @@ steps:
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
-        suppressionPath: $(suppressionsPath)
+    suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,10 +45,10 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -6,7 +6,7 @@ parameters:
     default: ''
   - name: runEvenIfError
     default: false
-  - name: continueIfVulnerabilities # Should the pipeline continue if vulnerabilities are found?
+  - name: continueIfVulnerabilities
     default: false
   - name: suppressionsFilePath
     default: '$(Build.SourcesDirectory)/suppressions.xml'
@@ -17,67 +17,74 @@ steps:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
+
   # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
     name: setVars
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
-    targetType: inline
-    pwsh: true
-    script: |
-      Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
+      targetType: inline
+      pwsh: true
+      script: |
+        Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
 
-      if (Test-Path "${{parameters.suppressionsFilePath}}") {
-        Write-Host "Suppressions file found"
-        Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
-        Write-Host "##vso[task.setvariable variable=hasSuppression]true"
-      }
-      else {
-        Write-Host "Suppressions file not found"
-        Write-Host "##vso[task.setvariable variable=hasSuppression]false"
-      }
+        if (Test-Path "${{parameters.suppressionsFilePath}}") {
+          Write-Host "Suppressions file found"
+          Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
+          Write-Host "##vso[task.setvariable variable=hasSuppression]true"
+        }
+        else {
+          Write-Host "Suppressions file not found"
+          Write-Host "##vso[task.setvariable variable=hasSuppression]false"
+        }
 
-# Step 2a: Dependency check WITH suppressions
+  # Step 2a: Dependency check WITH suppressions
   - task: dependency-check-build-task@6
     displayName: .NET Dependency Check (with suppressions)
     condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-    projectName: ${{parameters.projectName}}
-    scanPath: '**/*.csproj'
-    format: 'HTML,JUNIT'
-    failOnCVSS: '1'
-    additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-    suppressionPath: '$(suppressionsPath)'
+      projectName: ${{parameters.projectName}}
+      scanPath: '**/*.csproj'
+      format: 'HTML,JUNIT'
+      failOnCVSS: '1'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+      suppressionPath: '$(suppressionsPath)'
 
-# Step 2b: Dependency check WITHOUT suppressions
+  # Step 2b: Dependency check WITHOUT suppressions
   - task: dependency-check-build-task@6
     displayName: .NET Dependency Check (no suppressions)
     condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-    projectName: ${{parameters.projectName}}
-    scanPath: '**/*.csproj'
-    format: 'HTML,JUNIT'
-    failOnCVSS: '1'
-    additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-    # Check if report exists, when not skipped and artifact name provided
-  - powershell: |
-      if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {
-        echo "##vso[task.setVariable variable=ReportExists]true"
-      }
+      projectName: ${{parameters.projectName}}
+      scanPath: '**/*.csproj'
+      format: 'HTML,JUNIT'
+      failOnCVSS: '1'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+
+  # Check if dependency-check report exists
+  - task: PowerShell@2
     displayName: Check for Dependency Check Report
     condition: and(succeededOrFailed(), ne('${{parameters.publishAs}}', ''))
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        if (Test-Path "$(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html") {
+          Write-Host "##vso[task.setVariable variable=ReportExists]true"
+        }
 
-    # Republish report to unique artifact
+  # Republish the report as an artifact
   - publish: $(Common.TestResultsDirectory)\dependency-check
-    condition: eq(variables.ReportExists, 'true')
     displayName: Republish Dependency Check Report
+    condition: eq(variables['ReportExists'], 'true')
     artifact: ${{parameters.publishAs}}
 
+  # Publish JUnit results
   - task: PublishTestResults@2
-    displayName: "Publish JUnit Results"
+    displayName: Publish JUnit Results
     condition: succeededOrFailed()
     inputs:
       testResultsFormat: 'JUnit'

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -20,7 +20,6 @@ steps:
 
   - task: PowerShell@2
     displayName: 'Debug suppression path'
-    condition: always()
     inputs:
       targetType: 'inline'
       pwsh: true

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -25,7 +25,7 @@ steps:
       targetType: 'inline'
       pwsh: true
       script: |
-        $filePath = "$(Build.SourcesDirectory)"
+        $filePath = "${{ parameters.suppressionsFilePath }}"
         Write-Host "Listing contents of folder containing suppression file:"
         $dir = Split-Path -Path $filePath
         Get-ChildItem -Path $dir

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -35,11 +35,13 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-          Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
+         $filePath = "${{ parameters.suppressionsFilePath }}"
+   
+          Write-Host "Checking for: $filePath"
 
-          if (Test-Path ${{parameters.suppressionsFilePath}} ){
+          if (Test-Path $filePath ){
             Write-Host "Suppressions file found"
-            echo "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
+            echo "##vso[task.setvariable variable=suppressionsPath]$filePath"
           }
           else {
             Write-Host "Suppressions file not found, no suppressions will be provided"

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -28,7 +28,7 @@ steps:
         $filePath = "$(Build.SourcesDirectory)"
         Write-Host "Listing contents of folder containing suppression file:"
         $dir = Split-Path -Path $filePath
-        Get-ChildItem -Path $dir
+        Get-ChildItem -Path $dir -Recurse
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,6 +19,16 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
+    displayName: 'Download base suppression file'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
+        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
+        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
+        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
+
+  - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
@@ -49,7 +59,7 @@ steps:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if eq(variables['suppressionsPath'], '') }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression $(baseSuppressionFile)"'
 
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,10 +45,10 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -35,13 +35,11 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-         $filePath = "${{ parameters.suppressionsFilePath }}"
-   
-          Write-Host "Checking for: $filePath"
+          Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
 
-          if (Test-Path $filePath ){
+          if (Test-Path ${{parameters.suppressionsFilePath}} ){
             Write-Host "Suppressions file found"
-            echo "##vso[task.setvariable variable=suppressionsPath]$filePath"
+            echo "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
           }
           else {
             Write-Host "Suppressions file not found, no suppressions will be provided"

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -20,7 +20,6 @@ steps:
 
   # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
-    name: setVarsNuget
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -23,8 +23,9 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
+       $filePath = "${{ parameters.suppressionsFilePath }}"
        echo "Listing contents of suppression folder:"
-       dir "${{ parameters.suppressionsFilePath }}"
+       dir $filePath
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -48,7 +48,7 @@ steps:
       ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '')) }}:
+      ${{ if eq(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
 
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,11 +45,11 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
+        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,9 +45,11 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --hostedSuppressionsUrl "https://jeremylong.github.io/DependencyCheck/suppressions/publishedSuppressions.xml"'
+      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
+      ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
+        suppressionFile: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -25,7 +25,7 @@ steps:
       targetType: 'inline'
       pwsh: true
       script: |
-        $filePath = "${{ parameters.suppressionsFilePath }}"
+        $filePath = "$(Build.SourcesDirectory)"
         Write-Host "Listing contents of folder containing suppression file:"
         $dir = Split-Path -Path $filePath
         Get-ChildItem -Path $dir

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,13 +19,15 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-      displayName: 'Debug suppression path'
+    displayName: 'Debug suppression path'
     inputs:
       targetType: 'inline'
+      pwsh: true
       script: |
-       $filePath = "${{ parameters.suppressionsFilePath }}"
-       echo "Listing contents of suppression folder:"
-       dir $filePath
+        $filePath = "${{ parameters.suppressionsFilePath }}"
+        Write-Host "Listing contents of folder containing suppression file:"
+        $dir = Split-Path -Path $filePath
+        Get-ChildItem -Path $dir
 
   - task: PowerShell@2
     displayName: Find Suppressions File

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,12 +45,11 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      ${{ if ne(variables['suppressionsPath'], '') }}:
+      ${{ if and(ne(variables['suppressionsPath'], null), ne(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '')) }}:
+      ${{ if or(eq(variables['suppressionsPath'], null), eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
-
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -48,7 +48,7 @@ steps:
       ${{ if ne(variables['suppressionsPath'], '') }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
-      ${{ if eq(variables['suppressionsPath'], '') }}:
+      ${{ if eq(variables['suppressionsPath'], '')) }}:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
 
     # Check if report exists, when not skipped and artifact name provided

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -41,7 +41,8 @@ steps:
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      suppressionPath: $(suppressionsPath)
+      ${{ if ne(variables['suppressionsPath'], 'null') && ne(variables['suppressionsPath'], '') }}:
+        suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -17,36 +17,51 @@ steps:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
-
+  # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
+    name: setVars
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-          Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
+    targetType: inline
+    pwsh: true
+    script: |
+      Write-Host "Checking for: ${{parameters.suppressionsFilePath}}"
 
-          if (Test-Path ${{parameters.suppressionsFilePath}} ){
-            Write-Host "Suppressions file found"
-            echo "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
-          }
-          else {
-            Write-Host "Suppressions file not found, no suppressions will be provided"
-            echo "##vso[task.setvariable variable=suppressionsPath]$null"
-          }
+      if (Test-Path "${{parameters.suppressionsFilePath}}") {
+        Write-Host "Suppressions file found"
+        Write-Host "##vso[task.setvariable variable=suppressionsPath]${{parameters.suppressionsFilePath}}"
+        Write-Host "##vso[task.setvariable variable=hasSuppression]true"
+      }
+      else {
+        Write-Host "Suppressions file not found"
+        Write-Host "##vso[task.setvariable variable=hasSuppression]false"
+      }
 
+# Step 2a: Dependency check WITH suppressions
   - task: dependency-check-build-task@6
-    displayName: .NET Dependency Check
-    condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
+    displayName: .NET Dependency Check (with suppressions)
+    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      projectName: ${{parameters.projectName}}
-      scanPath: '**/*.csproj'
-      format: 'HTML,JUNIT'
-      failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-      suppressionPath: $(suppressionsPath)
+    projectName: ${{parameters.projectName}}
+    scanPath: '**/*.csproj'
+    format: 'HTML,JUNIT'
+    failOnCVSS: '1'
+    additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
+    suppressionPath: '$(suppressionsPath)'
+
+# Step 2b: Dependency check WITHOUT suppressions
+  - task: dependency-check-build-task@6
+    displayName: .NET Dependency Check (no suppressions)
+    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
+    continueOnError: ${{parameters.continueIfVulnerabilities}}
+    inputs:
+    projectName: ${{parameters.projectName}}
+    scanPath: '**/*.csproj'
+    format: 'HTML,JUNIT'
+    failOnCVSS: '1'
+    additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -41,7 +41,7 @@ steps:
   # Step 2a: Dependency check WITH suppressions
   - task: dependency-check-build-task@6
     displayName: .NET Dependency Check (with suppressions)
-    condition: and(succeeded(), eq(variables['hasSuppression'], 'true'))
+    condition: and(or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed())), eq(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
       projectName: ${{parameters.projectName}}
@@ -54,7 +54,7 @@ steps:
   # Step 2b: Dependency check WITHOUT suppressions
   - task: dependency-check-build-task@6
     displayName: .NET Dependency Check (no suppressions)
-    condition: and(succeeded(), ne(variables['hasSuppression'], 'true'))
+    condition: and(or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed())), ne(variables['hasSuppression'], 'true'))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
       projectName: ${{parameters.projectName}}

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -45,11 +45,11 @@ steps:
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
-      additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        additionalArguments: '--suppression https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -49,7 +49,7 @@ steps:
       ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
         suppressionPath: $(suppressionsPath)
       ${{ if or(eq(variables['suppressionsPath'], 'null'), eq(variables['suppressionsPath'], '')) }}:
-        suppressionPath: '$(Build.SourcesDirectory)/dependency-check-suppress.xml'
+        suppressionPath: 'https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml'
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -41,14 +41,13 @@ steps:
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     continueOnError: ${{parameters.continueIfVulnerabilities}}
     inputs:
-      ${{ if ne(variables['suppressionsPath'], 'null') && ne(variables['suppressionsPath'], '') }}:
-        suppressionPath: $(suppressionsPath)
       projectName: ${{parameters.projectName}}
       scanPath: '**/*.csproj'
       format: 'HTML,JUNIT'
       failOnCVSS: '1'
       additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
-
+      ${{ if and(ne(variables['suppressionsPath'], 'null'), ne(variables['suppressionsPath'], '')) }}:
+        suppressionPath: $(suppressionsPath)
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |
       if (Test-Path $(Common.TestResultsDirectory)\dependency-check\dependency-check-report.html) {

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -19,16 +19,6 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: PowerShell@2
-    displayName: 'Download base suppression file'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $suppressionUrl = "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"
-        $outputFile = "$(Build.SourcesDirectory)/base-suppression.xml"
-        Invoke-WebRequest -Uri $suppressionUrl -OutFile $outputFile
-        echo "##vso[task.setvariable variable=baseSuppressionFile]$outputFile"
-
-  - task: PowerShell@2
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:
@@ -59,7 +49,7 @@ steps:
         additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc"'
         suppressionPath: $(suppressionsPath)
       ${{ if eq(variables['suppressionsPath'], '') }}:
-        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression $(baseSuppressionFile)"'
+        additionalArguments: '--nvdApiKey "cb027565-2f22-4e16-8992-9bf0a9a0cadc" --suppression "https://raw.githubusercontent.com/dependency-check/DependencyCheck/refs/heads/main/core/src/main/resources/dependencycheck-base-suppression.xml"'
 
     # Check if report exists, when not skipped and artifact name provided
   - powershell: |

--- a/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
+++ b/src/security/dependency-check/steps/nuget-dependency-check.steps.yaml
@@ -20,7 +20,7 @@ steps:
 
   # Step 1: Set suppressionsPath (runtime variable)
   - task: PowerShell@2
-    name: setVars
+    name: setVarsNuget
     displayName: Find Suppressions File
     condition: or(succeeded(), and(eq('${{parameters.runEvenIfError}}', true), succeededOrFailed()))
     inputs:


### PR DESCRIPTION
The previous change worked as expected for no suppression path supplied builds but as we needed to suppress others, the suppressed build was not working as expected anymore.

This pull requests splits them into two separate steps for visibility of which path your current pipeline run is going down, and also fixes the suppression file provided path.

### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ❎ Changes do not require documentation

### Added/updated logging
- ✔ Most/all changed code contains appropriate pipeline logging

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ❎ No changes to secrets or variables

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ❌ Documentation for new/modified pipeline steps is missing

### Security vulnerabilities checked
- ❎ No new dependencies or changes affecting security

### Work item linked
- ❎ No work item exists and none is needed ( Still issue #44 )