### PR TITLE
Feature/206355 migrate solus to dependency track 

### DIFF
--- a/src/security/dependency-track/README.md
+++ b/src/security/dependency-track/README.md
@@ -1,4 +1,4 @@
-# Dependency-Track Pipeline Templates
+﻿# Dependency-Track Pipeline Templates
 
 These Azure Pipelines templates automate SBOM generation, upload to OWASP Dependency-Track, and optional deactivation of non-latest project versions.
 
@@ -23,7 +23,7 @@ Each upload creates or updates a project and version in Dependency-Track, which 
 > This approach ensures:
 > - A single, consolidated SBOM artifact for multi-ecosystem projects
 > - No duplicate or conflicting artifact names
-> - Consistent behavior between modular (staged) and end-to-end pipeline designs
+> - Consistent behaviour between modular (staged) and end-to-end pipeline designs
 
 ## Prerequisites
 
@@ -37,14 +37,15 @@ If using Azure DevOps, you can store the key as a secret in a variable group or 
 
 These are defined as pipeline variables within each YAML file or via the “Variables” tab in Azure DevOps.
 
-| Variable               | Purpose                                                               | Example                              |
-| ---------------------- | --------------------------------------------------------------------- | ------------------------------------ |
-| `envName`              | Which environment this SBOM represents                                | `dev`, `qa`, `uat`, `prod`           |
-| `version`              | Project version value used on upload e.g. `$(Build.SourceBranchName)` | `main`                               |
-| `additionalTags`       | Optional extra tags recorded on the Dependency-Track project          | `owner:team-x,service:abc`           |
-| `deactivateOld`        | Whether to mark all older versions inactive after upload              | `true`                               |
-| `parentProjectName`    | Optional parent “container” in Dependency-Track                       | `OrganisationName - ApplicationName` |
-| `parentProjectVersion` | Version of the parent (may be left empty)                             | `2025.10` or empty                   |
+| Variable               | Purpose                                                                                 | Example                              |
+| ---------------------- |-----------------------------------------------------------------------------------------| ------------------------------------ |
+| `envName`              | Which environment this SBOM represents                                                  | `dev`, `qa`, `uat`, `prod`           |
+| `version`              | Project version value used on upload e.g. `$(Build.SourceBranchName)`                   | `main`                               |
+| `additionalTags`       | Optional extra tags recorded on the Dependency-Track project                            | `owner:team-x,service:abc`           |
+| `deactivateOld`        | Whether to mark all older versions inactive after upload                                | `true`                               |
+| `parentProjectName`    | Optional parent “container” in Dependency-Track                                         | `OrganisationName - ApplicationName` |
+| `parentProjectVersion` | Version of the parent (may be left empty)                                               | `2025.10` or empty                   |
+| `waitForProcessing`    | Whether to wait for BOM processing in Dependency-Track before finishing the upload step | `true`                               |
 
 > ⚠️ Parent projects must match on both name and version exactly (case-sensitive) in Dependency-Track for the link to be established. If the version is left empty or no exact match exists, uploads still succeed but no parent link is created.
 
@@ -136,13 +137,14 @@ to maintain accurate evidence and reproducibility.
 
 ## Troubleshooting
 
-| Symptom                                  | Likely cause                                             | Fix                                                                                       |
-| ---------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `401 Unauthorized` on upload             | API key invalid or expired                                | Regenerate in Dependency-Track and update the variable group                              |
-| SBOM not linked to parent                | Name or version mismatch                                  | Ensure exact parent match exists in Dependency-Track                                      |
-| “No SBOM files to upload”                | Wrong paths or missing lockfiles                          | Check `.csproj` and SPA root paths; ensure `package-lock.json` exists                     |
-| Deactivate skipped                       | SBOM artifact missing                                     | Keep `tryDownloadArtifact: true`                                                          |
-| `ELSPROBLEMS` warning during npm SBOM    | Dependency tree inconsistencies detected by `npm ls`       | SBOMs still upload successfully; align dependency versions to remove warnings             |
+| Symptom                                | Likely cause                                                      | Fix                                                                           |
+|----------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `401 Unauthorized` on upload           | API key invalid or expired                                        | Regenerate in Dependency-Track and update the variable group                  |
+| SBOM not linked to parent              | Name or version mismatch                                          | Ensure exact parent match exists in Dependency-Track                          |
+| “No SBOM files to upload”              | Wrong paths or missing lockfiles                                  | Check `.csproj` and SPA root paths; ensure `package-lock.json` exists         |
+| Deactivate skipped                     | SBOM artifact missing                                             | Keep `tryDownloadArtifact: true`                                              |
+| `ELSPROBLEMS` warning during npm SBOM  | Dependency tree inconsistencies detected by `npm ls`              | SBOMs still upload successfully; align dependency versions to remove warnings |
+| Upload stage runs too long / times out | Dependency-Track is still processing BOMs when the pipeline waits | Set `waitForProcessing: false` to skip waiting for processing                 |
 
 ## Verification Checklist
 

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -1,4 +1,4 @@
-# Template: download → build tags → preflight discovery/validation → upload with token wait → summary → verify
+﻿# Template: download â†’ build tags â†’ preflight discovery/validation â†’ upload with token wait â†’ summary â†’ verify
 
 parameters:
   # The name of the artifact produced by earlier steps. Must match the publish task's artifact name.
@@ -162,7 +162,7 @@ steps:
               $projectVersion = $sbomVersion
             } else {
               $projectVersion = ''
-              Write-Warning "No version parameter supplied and SBOM has no metadata.component.version → using an empty string for: $projectName"
+              Write-Warning "No version parameter supplied and SBOM has no metadata.component.version â†’ using an empty string for: $projectName"
             }
           }
 
@@ -176,7 +176,7 @@ steps:
         if ($uploadMatrix.Count -eq 0) { throw "No valid SBOMs after preflight validation; cannot build upload matrix." }
         $uploadMatrixPath = Join-Path $env:AGENT_TEMPDIRECTORY 'dt-upload-matrix.json'
         ($uploadMatrix | ConvertTo-Json -Depth 4 -Compress) | Set-Content -LiteralPath $uploadMatrixPath -Encoding UTF8
-        Write-Host "##[section]Preflight summary → valid=$($uploadMatrix.Count), invalid=$invalidCount"
+        Write-Host "##[section]Preflight summary â†’ valid=$($uploadMatrix.Count), invalid=$invalidCount"
         Write-Host "Matrix path: $uploadMatrixPath"
         Write-Host "##vso[task.setvariable variable=UploadMatrixPath;isOutput=true]$uploadMatrixPath"
 
@@ -210,7 +210,7 @@ steps:
         $parentProjectNameParam    = '${{ parameters.parentProjectName }}'
         $parentProjectVersionParam = '${{ parameters.parentProjectVersion }}'
         if ($parentProjectNameParam) {
-          Write-Host "Parent project specified → Name='$parentProjectNameParam' Version='$parentProjectVersionParam'"
+          Write-Host "Parent project specified â†’ Name='$parentProjectNameParam' Version='$parentProjectVersionParam'"
         } else {
           Write-Host "No parent project specified; uploads will not set parentName/parentVersion."
         }
@@ -232,6 +232,11 @@ steps:
           $deadline = (Get-Date).AddSeconds($timeoutSec)
           while ((Get-Date) -lt $deadline) {
             try {
+              Write-Host "RequestId: $requestId"
+              Write-Host ("BOM file: {0} ({1:N0} bytes)" -f $bomFile.FullName, $bomFile.Length)
+              Write-Host ("API base: {0}" -f $apiBaseUrl)
+              if ($parentProjectNameParam) { Write-Host ("Parent: {0} / {1}" -f $parentProjectNameParam, $parentProjectVersionParam) }
+              if ($env:PROJECT_TAGS_CSV) { Write-Host ("Project tags: {0}" -f $env:PROJECT_TAGS_CSV) }
               $response = $httpClient.GetAsync("$apiBaseUrl/v1/bom/token/$token").GetAwaiter().GetResult()
               $responseText  = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
               if ($response.IsSuccessStatusCode) {
@@ -256,7 +261,14 @@ steps:
           foreach ($uploadItem in $uploadMatrix) {
             $bomFile = Get-Item -LiteralPath $uploadItem.FilePath
             Write-Host "##[group]Uploading SBOM -> $($uploadItem.ProjectName) @ $($uploadItem.ProjectVersion)"
+            $requestId = [guid]::NewGuid().ToString()
+            $response = $null
             try {
+              Write-Host "RequestId: $requestId"
+              Write-Host ("BOM file: {0} ({1:N0} bytes)" -f $bomFile.FullName, $bomFile.Length)
+              Write-Host ("API base: {0}" -f $apiBaseUrl)
+              if ($parentProjectNameParam) { Write-Host ("Parent: {0} / {1}" -f $parentProjectNameParam, $parentProjectVersionParam) }
+              if ($env:PROJECT_TAGS_CSV) { Write-Host ("Project tags: {0}" -f $env:PROJECT_TAGS_CSV) }
               $multipartForm = [System.Net.Http.MultipartFormDataContent]::new()
               $multipartForm.Add([System.Net.Http.StringContent]::new('true'), 'autoCreate')
               $multipartForm.Add([System.Net.Http.StringContent]::new('true'), 'isLatest')
@@ -289,6 +301,10 @@ steps:
 
               if (-not $response.IsSuccessStatusCode) {
                 $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                Write-Host "##vso[task.logissue type=error]Dependency-Track upload failed (HTTP $($response.StatusCode))."
+                if ($responseBody) { Write-Host "##vso[task.logissue type=error]Response body: $responseBody" }
+                $respHeaders = ($response.Headers | Out-String).Trim()
+                if ($respHeaders) { Write-Host "Response headers:`n$respHeaders" }
                 throw "HTTP $($response.StatusCode) - $responseBody"
               }
 
@@ -299,7 +315,15 @@ steps:
 
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
-              Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
+              Write-Error "âŒ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
+              Write-Host ("Exception type: {0}" -f $_.Exception.GetType().FullName)
+              if ($response) {
+                Write-Host ("Last response status: {0}" -f $response.StatusCode)
+                try {
+                  $lastBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+                  if ($lastBody) { Write-Host "Last response body: $lastBody" }
+                } catch {}
+              }
               throw
             } finally {
               Write-Host "##[endgroup]"
@@ -309,7 +333,7 @@ steps:
           $uploadedRowsJson = ($uploadedRows | ConvertTo-Json -Compress); if (-not $uploadedRowsJson) { $uploadedRowsJson = '[]' }
           Write-Host "##vso[task.setvariable variable=uploadedRowsJson;isOutput=true]$uploadedRowsJson"
           Set-Content -LiteralPath (Join-Path $env:AGENT_TEMPDIRECTORY 'dt-uploaded-rows.json') -Value $uploadedRowsJson -Encoding UTF8
-          Write-Host "##[section]✅ All uploads completed successfully"
+          Write-Host "##[section]âœ… All uploads completed successfully"
         } catch {
           $uploadedRowsJson = ($uploadedRows | ConvertTo-Json -Compress); if (-not $uploadedRowsJson) { $uploadedRowsJson = '[]' }
           Write-Host "##vso[task.setvariable variable=uploadedRowsJson;isOutput=true]$uploadedRowsJson"

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -21,6 +21,11 @@ parameters:
     type: number
     default: 300
 
+  # When true, wait for each BOM token to finish processing; when false, upload only.
+  - name: waitForProcessing
+    type: boolean
+    default: true
+
   # The parent project to associate with uploads. Sets parentName/parentVersion when provided.
   - name: parentProjectName
     type: string
@@ -311,7 +316,11 @@ steps:
               $uploadResponse = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult() | ConvertFrom-Json
               $tokenNote = "token: $($uploadResponse.token)"
               Write-Host "Uploaded OK: $($bomFile.FullName) ($tokenNote)"
-              [void](Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }})
+              if ("${{ parameters.waitForProcessing }}" -eq "True") {
+                [void](Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }})
+              } else {
+                Write-Host "Skipping BOM processing wait (upload only)."
+              }
 
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -21,6 +21,8 @@ parameters:
     type: number
     default: 300
 
+  # WARNING: false speeds up pipelines but verification may be stale/missing until processing completes.
+  # Use false only when you accept delayed project visibility/validation in Dependency-Track.
   # When true, wait for each BOM token to finish processing; when false, upload only.
   - name: waitForProcessing
     type: boolean
@@ -319,7 +321,7 @@ steps:
               if ("${{ parameters.waitForProcessing }}" -eq "True") {
                 [void](Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }})
               } else {
-                Write-Host "Skipping BOM processing wait (upload only)."
+                Write-Warning "Skipping BOM processing wait; project verification may be stale until processing completes."
               }
 
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
@@ -374,6 +376,7 @@ steps:
 
   - task: PowerShell@2
     displayName: "Verify Dependency-Track project state (post-upload)"
+    condition: and(succeeded(), eq('${{ parameters.waitForProcessing }}','true'))
     env:
       DT_API_URL: $(DT_API_URL)
       DT_API_KEY: $(DT_API_KEY)

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -1,4 +1,4 @@
-﻿# Template: download â†’ build tags â†’ preflight discovery/validation â†’ upload with token wait â†’ summary â†’ verify
+﻿# Template: download → build tags → preflight discovery/validation → upload with token wait → summary → verify
 
 parameters:
   # The name of the artifact produced by earlier steps. Must match the publish task's artifact name.
@@ -169,7 +169,7 @@ steps:
               $projectVersion = $sbomVersion
             } else {
               $projectVersion = ''
-              Write-Warning "No version parameter supplied and SBOM has no metadata.component.version â†’ using an empty string for: $projectName"
+              Write-Warning "No version parameter supplied and SBOM has no metadata.component.version → using an empty string for: $projectName"
             }
           }
 
@@ -183,7 +183,7 @@ steps:
         if ($uploadMatrix.Count -eq 0) { throw "No valid SBOMs after preflight validation; cannot build upload matrix." }
         $uploadMatrixPath = Join-Path $env:AGENT_TEMPDIRECTORY 'dt-upload-matrix.json'
         ($uploadMatrix | ConvertTo-Json -Depth 4 -Compress) | Set-Content -LiteralPath $uploadMatrixPath -Encoding UTF8
-        Write-Host "##[section]Preflight summary â†’ valid=$($uploadMatrix.Count), invalid=$invalidCount"
+        Write-Host "##[section]Preflight summary → valid=$($uploadMatrix.Count), invalid=$invalidCount"
         Write-Host "Matrix path: $uploadMatrixPath"
         Write-Host "##vso[task.setvariable variable=UploadMatrixPath;isOutput=true]$uploadMatrixPath"
 
@@ -217,7 +217,7 @@ steps:
         $parentProjectNameParam    = '${{ parameters.parentProjectName }}'
         $parentProjectVersionParam = '${{ parameters.parentProjectVersion }}'
         if ($parentProjectNameParam) {
-          Write-Host "Parent project specified â†’ Name='$parentProjectNameParam' Version='$parentProjectVersionParam'"
+          Write-Host "Parent project specified → Name='$parentProjectNameParam' Version='$parentProjectVersionParam'"
         } else {
           Write-Host "No parent project specified; uploads will not set parentName/parentVersion."
         }
@@ -326,7 +326,7 @@ steps:
 
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
-              Write-Error "âŒ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
+              Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
               Write-Host ("Exception type: {0}" -f $_.Exception.GetType().FullName)
               if ($response) {
                 Write-Host ("Last response status: {0}" -f $response.StatusCode)
@@ -344,7 +344,7 @@ steps:
           $uploadedRowsJson = ($uploadedRows | ConvertTo-Json -Compress); if (-not $uploadedRowsJson) { $uploadedRowsJson = '[]' }
           Write-Host "##vso[task.setvariable variable=uploadedRowsJson;isOutput=true]$uploadedRowsJson"
           Set-Content -LiteralPath (Join-Path $env:AGENT_TEMPDIRECTORY 'dt-uploaded-rows.json') -Value $uploadedRowsJson -Encoding UTF8
-          Write-Host "##[section]âœ… All uploads completed successfully"
+          Write-Host "##[section]✅ All uploads completed successfully"
         } catch {
           $uploadedRowsJson = ($uploadedRows | ConvertTo-Json -Compress); if (-not $uploadedRowsJson) { $uploadedRowsJson = '[]' }
           Write-Host "##vso[task.setvariable variable=uploadedRowsJson;isOutput=true]$uploadedRowsJson"


### PR DESCRIPTION
# Change Note: Dependency-Track Upload Timeouts (Solus)

## Summary
The Solus pipeline was timing out during the **Upload SBOMs to Dependency-Track** stage. By default, the upload template posts each BOM to `/v1/bom`, then waits for the returned token to reach **DONE** by polling `/v1/bom/token/{token}` in the **Upload SBOMs to Dependency-Track** step. On our instance the tokens remained **PROCESSING** for long periods, so the wait loop kept the job running until the pipeline timed out and was cancelled. The uploads themselves succeeded; the issue was the post‑upload processing wait exceeding the job timeout.

## Options Considered
1) **Keep waiting for BOM processing (default behaviour)**
   - **Pros:** Immediate confirmation that each BOM is fully ingested; post‑upload verification is reliable.
   - **Cons:** Slow on busy instances; can exceed pipeline/job timeouts when processing is backlogged.

2) **Reduce the processing timeout**
   - **Pros:** Limits worst‑case waiting while keeping the check.
   - **Cons:** Still blocks the pipeline and may produce timeouts or partial waits when the server is slow.

3) **Skip waiting for processing**
   - **Pros:** Fast and reliable pipeline completion; avoids long‑running jobs.
   - **Cons:** Verification immediately after upload may be stale until Dependency‑Track finishes processing.

## Decision
This has introduced a **non‑breaking** parameter, `waitForProcessing` (default `true`), to allow teams to opt out of waiting. For Solus I set `waitForProcessing: false` to prevent pipeline timeouts while keeping uploads intact. This preserves existing behaviour for other pipelines unless explicitly changed.

## How to Use
Set in the upload template parameters:

```yaml
waitForProcessing: false
```

When set to `false`, the verification step is skipped and a warning is logged explaining the trade‑off.


### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Added/updated logging
- ✔ Most/all changed code contains appropriate pipeline logging

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ✔ All secrets and variables are securely managed and documented

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ✔ All new/modified pipeline steps are documented

### Security vulnerabilities checked
- ❎ No new dependencies or changes affecting security

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR
