### PR TITLE
fix: Replace MSBuild with build via DotNetCoreCLI in nuget signing job #211055

### DIFF
--- a/src/build/dotnet/jobs/signed-nuget-package.job.yaml
+++ b/src/build/dotnet/jobs/signed-nuget-package.job.yaml
@@ -80,13 +80,14 @@ jobs:
         inputs:
           secureFile: audacia.snk
 
-      - task: MSBuild@1
+      - task: DotNetCoreCLI@2
         displayName: .NET Build
         inputs:
-          solution: ${{parameters.projects}}
-          msbuildArchitecture: x64
-          configuration: ${{parameters.configuration}}
-          msbuildArguments: /p:AssemblyOriginatorKeyFile=$(StrongNameCertificate.secureFilePath)
+          command: build
+          projects: ${{parameters.projects}}
+          arguments: >
+            --configuration ${{parameters.configuration}}
+            /p:AssemblyOriginatorKeyFile=$(StrongNameCertificate.secureFilePath)
 
       - task: DotNetCoreCLI@2
         displayName: .NET Test

--- a/src/build/dotnet/tasks/netcore/package-sign.yaml
+++ b/src/build/dotnet/tasks/netcore/package-sign.yaml
@@ -37,7 +37,7 @@ steps:
         foreach ($package in $packagesToSign) {
             Write-Host "Signing package $package"
             $path = $package.FullName
-            sign code trusted-signing "$path" `
+            sign code artifact-signing "$path" `
               --azure-credential-type azure-cli `
               --trusted-signing-endpoint "${{ parameters.trustedSigningEndpoint }}" `
               --trusted-signing-account "${{ parameters.trustedSigningAccount }}" `

--- a/src/build/dotnet/tasks/netcore/package-sign.yaml
+++ b/src/build/dotnet/tasks/netcore/package-sign.yaml
@@ -39,9 +39,9 @@ steps:
             $path = $package.FullName
             sign code artifact-signing "$path" `
               --azure-credential-type azure-cli `
-              --trusted-signing-endpoint "${{ parameters.trustedSigningEndpoint }}" `
-              --trusted-signing-account "${{ parameters.trustedSigningAccount }}" `
-              --trusted-signing-certificate-profile "${{ parameters.trustedSigningCertificateProfile }}"
+              --artifact-signing-endpoint "${{ parameters.trustedSigningEndpoint }}" `
+              --artifact-signing-account "${{ parameters.trustedSigningAccount }}" `
+              --artifact-signing-certificate-profile "${{ parameters.trustedSigningCertificateProfile }}"
         }
         # All packages will be signed with the same certificate, so only need to extract once
         Write-Host "Extracting package signing certificate"


### PR DESCRIPTION
### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ❎ Changes do not require documentation

### Added/updated logging
- ❎ No significant code changes

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ❎ No changes to secrets or variables

### Dependency licenses
- ✔ Licenses of new/upgraded dependencies checked, with no copyleft dependencies introduced

### Pipeline steps documented
- ❎ No changes to pipeline steps

### Security vulnerabilities checked
- ✔ No new security vulnerabilities introduced/external dependencies are secure and up-to-date

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR