### PR TITLE
feat: Enhance version inference to include Directory.Build.props for NET projects #211576

### DIFF
--- a/src/security/dependency-track/README.md
+++ b/src/security/dependency-track/README.md
@@ -40,7 +40,7 @@ These are defined as pipeline variables within each YAML file or via the “Vari
 | Variable               | Purpose                                                                                 | Example                              |
 | ---------------------- |-----------------------------------------------------------------------------------------| ------------------------------------ |
 | `envName`              | Which environment this SBOM represents                                                  | `dev`, `qa`, `uat`, `prod`           |
-| `version`              | Project version value used on upload e.g. `$(Build.SourceBranchName)`                   | `main`                               |
+| `version`              | Optional project version value used on upload. If set, this takes precedence over inferred SBOM versions. | `main`                               |
 | `additionalTags`       | Optional extra tags recorded on the Dependency-Track project                            | `owner:team-x,service:abc`           |
 | `deactivateOld`        | Whether to mark all older versions inactive after upload                                | `true`                               |
 | `parentProjectName`    | Optional parent “container” in Dependency-Track                                         | `OrganisationName - ApplicationName` |
@@ -48,6 +48,18 @@ These are defined as pipeline variables within each YAML file or via the “Vari
 | `waitForProcessing`    | Whether to wait for BOM processing in Dependency-Track before finishing the upload step | `true`                               |
 
 > ⚠️ Parent projects must match on both name and version exactly (case-sensitive) in Dependency-Track for the link to be established. If the version is left empty or no exact match exists, uploads still succeed but no parent link is created.
+
+## Project Versioning
+
+Dependency-Track uses the version supplied during the upload step. If the upload template's `version` parameter is set, that manually defined value takes precedence over any version in the generated SBOM.
+
+If `version` is left empty, the upload step uses `metadata.component.version` from the SBOM when available. For .NET SBOM generation, when `inferVersionFromProject` is enabled, the effective precedence is:
+
+1. The manually supplied upload `version` parameter.
+2. `PackageVersion`, then `Version`, in the nearest `Directory.Build.props` found by walking up from the `.csproj` directory.
+3. `PackageVersion`, then `Version`, in the `.csproj`.
+
+If no version is found, the project version is uploaded as an empty string.
 
 ## Specifying Projects for SBOM Generation
 

--- a/src/security/dependency-track/README.md
+++ b/src/security/dependency-track/README.md
@@ -128,10 +128,14 @@ If no exact match is found, the child projects still upload successfully but rem
 
 Use the convention `"<Client> - <System>"` for all parent project names to keep the portfolio consistent.
 
+## Latest and Active Version Handling
+
+When `waitForProcessing` is `true`, the upload step waits for Dependency-Track to finish processing each BOM and then promotes the uploaded `projectName + projectVersion` so it is marked as both latest and active.
+
 ## Deactivate Non-Latest Versions
 
-After a successful upload, older versions of each project (where `isLatest=false`) are set to inactive.
-This keeps the UI focused on the active release while preserving historical versions for audit.
+After the uploaded version has been promoted, older versions of each project (where `isLatest=false`) are set to inactive.
+This keeps the UI focused on the current release while preserving historical versions for audit.
 
 ## npm Dependency Tree Warnings
 
@@ -157,6 +161,7 @@ to maintain accurate evidence and reproducibility.
 | Deactivate skipped                     | SBOM artifact missing                                             | Keep `tryDownloadArtifact: true`                                              |
 | `ELSPROBLEMS` warning during npm SBOM  | Dependency tree inconsistencies detected by `npm ls`              | SBOMs still upload successfully; align dependency versions to remove warnings |
 | Upload stage runs too long / times out | Dependency-Track is still processing BOMs when the pipeline waits | Set `waitForProcessing: false` to skip waiting for processing                 |
+| Uploaded version is not latest or active | Dependency-Track did not finish processing in time, or the uploaded project could not be promoted | Keep `waitForProcessing: true` and review the upload step logs for the project lookup or patch failure |
 
 ## Verification Checklist
 
@@ -167,3 +172,4 @@ to maintain accurate evidence and reproducibility.
 - [ ] Parent project created in Dependency-Track
 - [ ] Parent project variables set (`"<Organisation> - <System>"`)
 - [ ] Pipeline variables defined: `envName`, `version`, `deactivateOld`, `additionalTags` (optional)
+

--- a/src/security/dependency-track/README.md
+++ b/src/security/dependency-track/README.md
@@ -56,7 +56,7 @@ Dependency-Track uses the version supplied during the upload step. If the upload
 If `version` is left empty, the upload step uses `metadata.component.version` from the SBOM when available. For .NET SBOM generation, when `inferVersionFromProject` is enabled, the effective precedence is:
 
 1. The manually supplied upload `version` parameter.
-2. `PackageVersion`, then `Version`, in the nearest `Directory.Build.props` found by walking up from the `.csproj` directory.
+2. `PackageVersion`, then `Version`, in the nearest `Directory.Build.props` found by walking up from the `.csproj` directory within the repository working directory.
 3. `PackageVersion`, then `Version`, in the `.csproj`.
 
 If no version is found, the project version is uploaded as an empty string.

--- a/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
@@ -67,7 +67,8 @@ parameters:
     type: string
     default: ''
 
-  # When enabled, the script tries PackageVersion, then Version from the .csproj.
+  # When enabled, the script tries PackageVersion, then Version from the nearest Directory.Build.props,
+  # then PackageVersion and Version from the .csproj.
   - name: inferVersionFromProject
     type: boolean
     default: true
@@ -249,7 +250,8 @@ steps:
         $outputRoot = "$(Agent.TempDirectory)/sbom/dotnet"
         New-Item -ItemType Directory -Path $outputRoot -Force | Out-Null
 
-        function Get-ProjectVersionOrNull([string]$path) {
+        function Get-VersionFromMsBuildFileOrNull([string]$path) {
+          if (-not (Test-Path -LiteralPath $path)) { return $null }
           if ('${{ parameters.inferVersionFromProject }}' -ne 'True') { return $null }
           try {
             [xml]$xml = Get-Content -Raw -LiteralPath $path
@@ -258,6 +260,39 @@ steps:
             $val = $xml.SelectSingleNode('/Project/PropertyGroup/Version')
             if ($val -and $val.InnerText.Trim()) { return $val.InnerText.Trim() }
           } catch {}
+          return $null
+        }
+
+        function Get-NearestDirectoryBuildPropsOrNull([string]$projectPath) {
+          try {
+            $directory = Get-Item -LiteralPath (Split-Path -Parent $projectPath)
+            while ($directory) {
+              $propsPath = Join-Path $directory.FullName 'Directory.Build.props'
+              if (Test-Path -LiteralPath $propsPath) { return $propsPath }
+              $directory = $directory.Parent
+            }
+          } catch {}
+          return $null
+        }
+
+        function Get-ProjectVersionOrNull([string]$path) {
+          if ('${{ parameters.inferVersionFromProject }}' -ne 'True') { return $null }
+
+          $propsPath = Get-NearestDirectoryBuildPropsOrNull $path
+          if ($propsPath) {
+            $propsVersion = Get-VersionFromMsBuildFileOrNull $propsPath
+            if ($propsVersion) {
+              Write-Host "Version inferred from Directory.Build.props: $propsPath"
+              return $propsVersion
+            }
+          }
+
+          $projectVersion = Get-VersionFromMsBuildFileOrNull $path
+          if ($projectVersion) {
+            Write-Host "Version inferred from project file: $path"
+            return $projectVersion
+          }
+
           return $null
         }
 

--- a/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
@@ -265,10 +265,18 @@ steps:
 
         function Get-NearestDirectoryBuildPropsOrNull([string]$projectPath) {
           try {
+            $searchRootPath = $null
+            if ($env:BUILD_SOURCESDIRECTORY -and (Test-Path -LiteralPath $env:BUILD_SOURCESDIRECTORY)) {
+              $searchRootPath = (Get-Item -LiteralPath $env:BUILD_SOURCESDIRECTORY).FullName.TrimEnd('\\','/')
+            } elseif ($env:SYSTEM_DEFAULTWORKINGDIRECTORY -and (Test-Path -LiteralPath $env:SYSTEM_DEFAULTWORKINGDIRECTORY)) {
+              $searchRootPath = (Get-Item -LiteralPath $env:SYSTEM_DEFAULTWORKINGDIRECTORY).FullName.TrimEnd('\\','/')
+            }
+
             $directory = Get-Item -LiteralPath (Split-Path -Parent $projectPath)
             while ($directory) {
               $propsPath = Join-Path $directory.FullName 'Directory.Build.props'
               if (Test-Path -LiteralPath $propsPath) { return $propsPath }
+              if ($searchRootPath -and ($directory.FullName.TrimEnd('\\','/') -ieq $searchRootPath)) { break }
               $directory = $directory.Parent
             }
           } catch {}

--- a/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/generate-dotnet-sbom.steps.yaml
@@ -267,16 +267,16 @@ steps:
           try {
             $searchRootPath = $null
             if ($env:BUILD_SOURCESDIRECTORY -and (Test-Path -LiteralPath $env:BUILD_SOURCESDIRECTORY)) {
-              $searchRootPath = (Get-Item -LiteralPath $env:BUILD_SOURCESDIRECTORY).FullName.TrimEnd('\\','/')
+              $searchRootPath = (Get-Item -LiteralPath $env:BUILD_SOURCESDIRECTORY).FullName.TrimEnd('\','/')
             } elseif ($env:SYSTEM_DEFAULTWORKINGDIRECTORY -and (Test-Path -LiteralPath $env:SYSTEM_DEFAULTWORKINGDIRECTORY)) {
-              $searchRootPath = (Get-Item -LiteralPath $env:SYSTEM_DEFAULTWORKINGDIRECTORY).FullName.TrimEnd('\\','/')
+              $searchRootPath = (Get-Item -LiteralPath $env:SYSTEM_DEFAULTWORKINGDIRECTORY).FullName.TrimEnd('\','/')
             }
 
             $directory = Get-Item -LiteralPath (Split-Path -Parent $projectPath)
             while ($directory) {
               $propsPath = Join-Path $directory.FullName 'Directory.Build.props'
               if (Test-Path -LiteralPath $propsPath) { return $propsPath }
-              if ($searchRootPath -and ($directory.FullName.TrimEnd('\\','/') -ieq $searchRootPath)) { break }
+              if ($searchRootPath -and ($directory.FullName.TrimEnd('\','/') -ieq $searchRootPath)) { break }
               $directory = $directory.Parent
             }
           } catch {}

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -262,6 +262,31 @@ steps:
           Write-Warning "BOM token $token did not reach DONE within timeout."
           return $false
         }
+        function Get-ProjectByNameVersion([string]$projectName, [string]$projectVersion) {
+          $encName = [uri]::EscapeDataString($projectName)
+          $encVersion = [uri]::EscapeDataString($projectVersion)
+          $response = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
+          $responseText = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+          if ($response.IsSuccessStatusCode) { return $responseText | ConvertFrom-Json }
+          return $null
+        }
+
+        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
+          $project = Get-ProjectByNameVersion -projectName $projectName -projectVersion $projectVersion
+          if (-not $project -or -not $project.uuid) {
+            throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion"
+          }
+
+          $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
+          $patchBody = @{ active = $true; isLatest = $true } | ConvertTo-Json -Depth 4
+          $patchRequest.Content = [System.Net.Http.StringContent]::new($patchBody, [Text.Encoding]::UTF8, 'application/json')
+
+          $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
+          $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+          if (-not $patchResponse.IsSuccessStatusCode) {
+            throw "Failed to set uploaded project as current (HTTP $($patchResponse.StatusCode)): $patchResponseText"
+          }
+        }
 
         $uploadedRows = New-Object System.Collections.Generic.List[object]
         try {
@@ -324,6 +349,7 @@ steps:
                 Write-Warning "Skipping BOM processing wait; project verification may be stale until processing completes."
               }
 
+              Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
               Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -281,7 +281,7 @@ steps:
               }
             } catch {
               $lookupError = $_.Exception.Message
-              Write-Warning "Lookup attempt failed for $projectName @ $projectVersion: $lookupError"
+              Write-Warning "Lookup attempt failed for $projectName @ ${projectVersion}: $lookupError"
             }
 
             if ($project -and $project.uuid) { break }

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -262,20 +262,26 @@ steps:
           Write-Warning "BOM token $token did not reach DONE within timeout."
           return $false
         }
-        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
+        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion, [int]$lookupTimeoutSec = 120) {
           $encName = [uri]::EscapeDataString($projectName)
           $encVersion = [uri]::EscapeDataString($projectVersion)
           $project = $null
-          $deadline = (Get-Date).AddSeconds(30)
+          $deadline = (Get-Date).AddSeconds($lookupTimeoutSec)
           $lookupStatusCode = $null
           $lookupResponseText = $null
+          $lookupError = $null
 
           do {
-            $lookupResponse = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
-            $lookupStatusCode = [int]$lookupResponse.StatusCode
-            $lookupResponseText = $lookupResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-            if ($lookupResponse.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($lookupResponseText)) {
-              $project = $lookupResponseText | ConvertFrom-Json
+            try {
+              $lookupResponse = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
+              $lookupStatusCode = [int]$lookupResponse.StatusCode
+              $lookupResponseText = $lookupResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+              if ($lookupResponse.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($lookupResponseText)) {
+                $project = $lookupResponseText | ConvertFrom-Json
+              }
+            } catch {
+              $lookupError = $_.Exception.Message
+              Write-Warning "Lookup attempt failed for $projectName @ $projectVersion: $lookupError"
             }
 
             if ($project -and $project.uuid) { break }
@@ -283,7 +289,11 @@ steps:
           } while ((Get-Date) -lt $deadline)
 
           if (-not $project -or -not $project.uuid) {
-            throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion (lookup HTTP $lookupStatusCode, body: $lookupResponseText)"
+            $lookupContext = "lookup HTTP $lookupStatusCode, body: $lookupResponseText"
+            if ($lookupError) {
+              $lookupContext = "$lookupContext, last error: $lookupError"
+            }
+            throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion ($lookupContext)"
           }
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
@@ -356,8 +366,12 @@ steps:
               $tokenNote = "token: $($uploadResponse.token)"
               Write-Host "Uploaded OK: $($bomFile.FullName) ($tokenNote)"
               if ("${{ parameters.waitForProcessing }}" -eq "True") {
-                [void](Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }})
-                Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
+                $processingCompleted = Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }}
+                if ($processingCompleted) {
+                  Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion -lookupTimeoutSec ${{ parameters.bomProcessingTimeoutSec }}
+                } else {
+                  Write-Warning "Skipping latest/active promotion because BOM processing did not complete within the timeout."
+                }
               } else {
                 Write-Warning "Skipping BOM processing wait and latest/active promotion; project verification may be stale until processing completes."
               }

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -262,56 +262,33 @@ steps:
           Write-Warning "BOM token $token did not reach DONE within timeout."
           return $false
         }
-        function Get-ProjectByNameVersion([string]$projectName, [string]$projectVersion) {
+        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
           $encName = [uri]::EscapeDataString($projectName)
           $encVersion = [uri]::EscapeDataString($projectVersion)
-          $response = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
-          $responseText = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-          return [pscustomobject]@{
-            StatusCode = [int]$response.StatusCode
-            IsSuccess  = $response.IsSuccessStatusCode
-            Body       = $responseText
-            Project    = $(if ($response.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($responseText)) { $responseText | ConvertFrom-Json } else { $null })
-          }
-        }
+          $project = $null
+          $deadline = (Get-Date).AddSeconds(30)
 
-        function Get-ProjectByNameVersionWithRetry([string]$projectName, [string]$projectVersion, [int]$timeoutSec = 30) {
-          $deadline = (Get-Date).AddSeconds($timeoutSec)
           do {
-            $lookup = Get-ProjectByNameVersion -projectName $projectName -projectVersion $projectVersion
-            if ($lookup.Project -and $lookup.Project.uuid) {
-              return $lookup
+            $lookupResponse = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
+            $lookupResponseText = $lookupResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            if ($lookupResponse.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($lookupResponseText)) {
+              $project = $lookupResponseText | ConvertFrom-Json
             }
+
+            if ($project -and $project.uuid) { break }
             Start-Sleep -Seconds 2
           } while ((Get-Date) -lt $deadline)
 
-          return $lookup
-        }
-
-        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
-          $lookup = Get-ProjectByNameVersionWithRetry -projectName $projectName -projectVersion $projectVersion
-          Write-Host ("Lookup status for {0} @ {1}: {2}" -f $projectName, $projectVersion, $lookup.StatusCode)
-          if ($lookup.Body) {
-            Write-Host ("Lookup response: {0}" -f $lookup.Body)
-          }
-
-          $project = $lookup.Project
           if (-not $project -or -not $project.uuid) {
             throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion"
           }
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
           $patchBody = @{ active = $true; isLatest = $true } | ConvertTo-Json -Depth 4
-          Write-Host ("Patch request body for {0} @ {1}: {2}" -f $projectName, $projectVersion, $patchBody)
           $patchRequest.Content = [System.Net.Http.StringContent]::new($patchBody, [Text.Encoding]::UTF8, 'application/json')
 
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-          Write-Host ("Patch status for {0} @ {1}: {2}" -f $projectName, $projectVersion, ([int]$patchResponse.StatusCode))
-          if ($patchResponseText) {
-            Write-Host ("Patch response: {0}" -f $patchResponseText)
-          }
-
           if (-not $patchResponse.IsSuccessStatusCode) {
             throw "Failed to set uploaded project as current (HTTP $($patchResponse.StatusCode)): $patchResponseText"
           }

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -267,9 +267,12 @@ steps:
           $encVersion = [uri]::EscapeDataString($projectVersion)
           $project = $null
           $deadline = (Get-Date).AddSeconds(30)
+          $lookupStatusCode = $null
+          $lookupResponseText = $null
 
           do {
             $lookupResponse = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
+            $lookupStatusCode = [int]$lookupResponse.StatusCode
             $lookupResponseText = $lookupResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
             if ($lookupResponse.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($lookupResponseText)) {
               $project = $lookupResponseText | ConvertFrom-Json
@@ -280,7 +283,7 @@ steps:
           } while ((Get-Date) -lt $deadline)
 
           if (-not $project -or -not $project.uuid) {
-            throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion"
+            throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion (lookup HTTP $lookupStatusCode, body: $lookupResponseText)"
           }
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
@@ -290,7 +293,7 @@ steps:
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
           if (-not $patchResponse.IsSuccessStatusCode) {
-            throw "Failed to set uploaded project as current (HTTP $($patchResponse.StatusCode)): $patchResponseText"
+            throw "Failed to set uploaded project as current for $projectName @ $projectVersion (HTTP $($patchResponse.StatusCode)): $patchResponseText"
           }
         }
 
@@ -381,6 +384,8 @@ steps:
           $uploadedRowsJson = ($uploadedRows | ConvertTo-Json -Compress); if (-not $uploadedRowsJson) { $uploadedRowsJson = '[]' }
           Write-Host "##vso[task.setvariable variable=uploadedRowsJson;isOutput=true]$uploadedRowsJson"
           Set-Content -LiteralPath (Join-Path $env:AGENT_TEMPDIRECTORY 'dt-uploaded-rows.json') -Value $uploadedRowsJson -Encoding UTF8
+          Write-Error ("Upload stage failed: {0}" -f $_.Exception.Message)
+          Write-Host ("Exception type: {0}" -f $_.Exception.GetType().FullName)
           if ("${{ parameters.failOnUploadError }}" -eq "True") { exit 1 } else { exit 0 }
         }
 

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -271,20 +271,20 @@ steps:
           return $null
         }
 
-        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
+        function EnsureUploadedProjectIsActive([string]$projectName, [string]$projectVersion) {
           $project = Get-ProjectByNameVersion -projectName $projectName -projectVersion $projectVersion
           if (-not $project -or -not $project.uuid) {
             throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion"
           }
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
-          $patchBody = @{ active = $true; isLatest = $true } | ConvertTo-Json -Depth 4
+          $patchBody = @{ active = $true } | ConvertTo-Json -Depth 4
           $patchRequest.Content = [System.Net.Http.StringContent]::new($patchBody, [Text.Encoding]::UTF8, 'application/json')
 
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
           if (-not $patchResponse.IsSuccessStatusCode) {
-            throw "Failed to set uploaded project as current (HTTP $($patchResponse.StatusCode)): $patchResponseText"
+            throw "Failed to reactivate uploaded project (HTTP $($patchResponse.StatusCode)): $patchResponseText"
           }
         }
 
@@ -349,7 +349,7 @@ steps:
                 Write-Warning "Skipping BOM processing wait; project verification may be stale until processing completes."
               }
 
-              Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
+              EnsureUploadedProjectIsActive -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
               Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
@@ -455,3 +455,4 @@ steps:
         "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f "-------","-------","------","--------","----" | Write-Host
         foreach ($row in $verificationRows) { "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f $row.Project, $row.Version, $row.Exists, $row.IsLatest, ($row.Note -replace '\r?\n',' ') | Write-Host }
         Write-Host "##[endgroup]"
+

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -267,24 +267,53 @@ steps:
           $encVersion = [uri]::EscapeDataString($projectVersion)
           $response = $httpClient.GetAsync("$apiBaseUrl/v1/project/lookup?name=$encName&version=$encVersion").GetAwaiter().GetResult()
           $responseText = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-          if ($response.IsSuccessStatusCode) { return $responseText | ConvertFrom-Json }
-          return $null
+          return [pscustomobject]@{
+            StatusCode = [int]$response.StatusCode
+            IsSuccess  = $response.IsSuccessStatusCode
+            Body       = $responseText
+            Project    = $(if ($response.IsSuccessStatusCode -and -not [string]::IsNullOrWhiteSpace($responseText)) { $responseText | ConvertFrom-Json } else { $null })
+          }
         }
 
-        function EnsureUploadedProjectIsActive([string]$projectName, [string]$projectVersion) {
-          $project = Get-ProjectByNameVersion -projectName $projectName -projectVersion $projectVersion
+        function Get-ProjectByNameVersionWithRetry([string]$projectName, [string]$projectVersion, [int]$timeoutSec = 30) {
+          $deadline = (Get-Date).AddSeconds($timeoutSec)
+          do {
+            $lookup = Get-ProjectByNameVersion -projectName $projectName -projectVersion $projectVersion
+            if ($lookup.Project -and $lookup.Project.uuid) {
+              return $lookup
+            }
+            Start-Sleep -Seconds 2
+          } while ((Get-Date) -lt $deadline)
+
+          return $lookup
+        }
+
+        function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
+          $lookup = Get-ProjectByNameVersionWithRetry -projectName $projectName -projectVersion $projectVersion
+          Write-Host "Lookup status for $projectName @ $projectVersion: $($lookup.StatusCode)"
+          if ($lookup.Body) {
+            Write-Host "Lookup response: $($lookup.Body)"
+          }
+
+          $project = $lookup.Project
           if (-not $project -or -not $project.uuid) {
             throw "Uploaded project not found after BOM processing: $projectName @ $projectVersion"
           }
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
-          $patchBody = @{ active = $true } | ConvertTo-Json -Depth 4
+          $patchBody = @{ active = $true; isLatest = $true } | ConvertTo-Json -Depth 4
+          Write-Host "Patch request body for $projectName @ $projectVersion: $patchBody"
           $patchRequest.Content = [System.Net.Http.StringContent]::new($patchBody, [Text.Encoding]::UTF8, 'application/json')
 
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+          Write-Host "Patch status for $projectName @ $projectVersion: $([int]$patchResponse.StatusCode)"
+          if ($patchResponseText) {
+            Write-Host "Patch response: $patchResponseText"
+          }
+
           if (-not $patchResponse.IsSuccessStatusCode) {
-            throw "Failed to reactivate uploaded project (HTTP $($patchResponse.StatusCode)): $patchResponseText"
+            throw "Failed to set uploaded project as current (HTTP $($patchResponse.StatusCode)): $patchResponseText"
           }
         }
 
@@ -349,7 +378,7 @@ steps:
                 Write-Warning "Skipping BOM processing wait; project verification may be stale until processing completes."
               }
 
-              EnsureUploadedProjectIsActive -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
+              Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
               Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"
@@ -455,4 +484,5 @@ steps:
         "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f "-------","-------","------","--------","----" | Write-Host
         foreach ($row in $verificationRows) { "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f $row.Project, $row.Version, $row.Exists, $row.IsLatest, ($row.Note -replace '\r?\n',' ') | Write-Host }
         Write-Host "##[endgroup]"
+
 

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -292,6 +292,9 @@ steps:
 
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+          if ([int]$patchResponse.StatusCode -eq 304) {
+            return
+          }
           if (-not $patchResponse.IsSuccessStatusCode) {
             throw "Failed to set uploaded project as current for $projectName @ $projectVersion (HTTP $($patchResponse.StatusCode)): $patchResponseText"
           }

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -357,11 +357,11 @@ steps:
               Write-Host "Uploaded OK: $($bomFile.FullName) ($tokenNote)"
               if ("${{ parameters.waitForProcessing }}" -eq "True") {
                 [void](Wait-BomProcessed -token $uploadResponse.token -timeoutSec ${{ parameters.bomProcessingTimeoutSec }})
+                Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
               } else {
-                Write-Warning "Skipping BOM processing wait; project verification may be stale until processing completes."
+                Write-Warning "Skipping BOM processing wait and latest/active promotion; project verification may be stale until processing completes."
               }
 
-              Set-UploadedProjectAsCurrent -projectName $uploadItem.ProjectName -projectVersion $uploadItem.ProjectVersion
               $uploadedRows.Add([pscustomobject]@{ Project=$uploadItem.ProjectName; Version=$uploadItem.ProjectVersion })
             } catch {
               Write-Error "❌ Upload failed for $($bomFile.FullName): $($_.Exception.Message)"

--- a/src/security/dependency-track/steps/upload-sbom.steps.yaml
+++ b/src/security/dependency-track/steps/upload-sbom.steps.yaml
@@ -290,9 +290,9 @@ steps:
 
         function Set-UploadedProjectAsCurrent([string]$projectName, [string]$projectVersion) {
           $lookup = Get-ProjectByNameVersionWithRetry -projectName $projectName -projectVersion $projectVersion
-          Write-Host "Lookup status for $projectName @ $projectVersion: $($lookup.StatusCode)"
+          Write-Host ("Lookup status for {0} @ {1}: {2}" -f $projectName, $projectVersion, $lookup.StatusCode)
           if ($lookup.Body) {
-            Write-Host "Lookup response: $($lookup.Body)"
+            Write-Host ("Lookup response: {0}" -f $lookup.Body)
           }
 
           $project = $lookup.Project
@@ -302,14 +302,14 @@ steps:
 
           $patchRequest = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Patch, "$apiBaseUrl/v1/project/$($project.uuid)")
           $patchBody = @{ active = $true; isLatest = $true } | ConvertTo-Json -Depth 4
-          Write-Host "Patch request body for $projectName @ $projectVersion: $patchBody"
+          Write-Host ("Patch request body for {0} @ {1}: {2}" -f $projectName, $projectVersion, $patchBody)
           $patchRequest.Content = [System.Net.Http.StringContent]::new($patchBody, [Text.Encoding]::UTF8, 'application/json')
 
           $patchResponse = $httpClient.SendAsync($patchRequest).GetAwaiter().GetResult()
           $patchResponseText = $patchResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-          Write-Host "Patch status for $projectName @ $projectVersion: $([int]$patchResponse.StatusCode)"
+          Write-Host ("Patch status for {0} @ {1}: {2}" -f $projectName, $projectVersion, ([int]$patchResponse.StatusCode))
           if ($patchResponseText) {
-            Write-Host "Patch response: $patchResponseText"
+            Write-Host ("Patch response: {0}" -f $patchResponseText)
           }
 
           if (-not $patchResponse.IsSuccessStatusCode) {
@@ -484,5 +484,6 @@ steps:
         "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f "-------","-------","------","--------","----" | Write-Host
         foreach ($row in $verificationRows) { "{0,-50} {1,-16} {2,-7} {3,-9} {4}" -f $row.Project, $row.Version, $row.Exists, $row.IsLatest, ($row.Note -replace '\r?\n',' ') | Write-Host }
         Write-Host "##[endgroup]"
+
 
 


### PR DESCRIPTION
TLDR:
This change makes uploaded SBOM versions more consistently versioned (especially for shared .NET versioning via Directory.Build.props) and ensures the uploaded version is explicitly marked as the current/latest active version in Dependency-Track after processing.


### Code ready for review
- ✔ Code compiles, no debugging/console statements or commented out code left in

### YAML pipeline syntax validated
- ✔ YAML syntax is valid and pipeline runs successfully

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Added/updated logging
- ❎ No significant code changes

### Pipeline triggers verified
- ❎ No changes to pipeline triggers

### Secrets and variables managed
- ❎ No changes to secrets or variables

### Dependency licenses
- ❎ No new/upgraded dependencies

### Pipeline steps documented
- ❎ No changes to pipeline steps

### Security vulnerabilities checked
- ❎ No new dependencies or changes affecting security

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR
